### PR TITLE
fix: Correct CLI binary paths in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,8 +301,8 @@ jobs:
     - name: Prepare CLI assets with correct names
       run: |
         # Copy CLI binaries with correct names for release
-        cp ./artifacts/macos/warpdeck ./artifacts/macos/warpdeck-cli-macos
-        cp ./artifacts/linux/warpdeck ./artifacts/linux/warpdeck-cli-linux
+        cp ./artifacts/macos/warpdeck-cli/build/warpdeck ./artifacts/macos/warpdeck-cli-macos
+        cp ./artifacts/linux/warpdeck-cli/build/warpdeck ./artifacts/linux/warpdeck-cli-linux
 
     - name: Generate release tag
       id: tag


### PR DESCRIPTION
## Summary
Fixes the release workflow that was failing at the 'Prepare CLI assets' step.

## Root Cause  
The CLI binaries are uploaded in the artifact structure as:
- `warpdeck-cli/build/warpdeck`

But the release script was looking for them at:
- `./artifacts/macos/warpdeck` 
- `./artifacts/linux/warpdeck`

## Fix
Updated paths to match the actual artifact structure:
- `./artifacts/macos/warpdeck-cli/build/warpdeck`
- `./artifacts/linux/warpdeck-cli/build/warpdeck`

## Expected Result
- Release workflow completes successfully  
- CLI binaries are properly renamed and included in release
- First release is finally created\!
- Download links work

🤖 Generated with [Claude Code](https://claude.ai/code)