### PR TITLE
Rewrite README as a focused project introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,834 +1,205 @@
-# WarpDeck 🚀
+# WarpDeck
 
-**Secure, fast, and beautiful peer-to-peer file sharing for macOS, Linux, and Steam Deck.**
+**AirDrop for the rest of us.** Cross-platform, peer-to-peer file sharing between macOS, Linux, and Steam Deck. No cloud. No accounts. No setup.
 
-[![GitHub Release](https://img.shields.io/github/v/release/deepc0py/WarpDeck?color=blue)](https://github.com/deepc0py/WarpDeck/releases/latest)
-[![Build Status](https://github.com/deepc0py/WarpDeck/workflows/Build%20and%20Test/badge.svg)](https://github.com/deepc0py/WarpDeck/actions/workflows/build.yml)
-[![Release Status](https://github.com/deepc0py/WarpDeck/workflows/Build%20and%20Release/badge.svg)](https://github.com/deepc0py/WarpDeck/actions/workflows/release.yml)
+[![Build and Release](https://github.com/deepc0py/WarpDeck/actions/workflows/release.yml/badge.svg)](https://github.com/deepc0py/WarpDeck/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Platform Support](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20Steam%20Deck-lightgrey)](https://github.com/deepc0py/WarpDeck)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Steam%20Deck-blue)]()
 
-WarpDeck brings secure, lightning-fast peer-to-peer file sharing directly between your devices. No cloud required, no tracking, just direct device-to-device transfers with beautiful native applications.
+---
 
-## ✨ Features
+WarpDeck discovers nearby devices automatically via mDNS, encrypts every transfer with TLS 1.3, and remembers trusted devices using a Trust-On-First-Use model (like SSH). Drop files onto a device name and they arrive on the other side. That's it.
 
-- 🔒 **Privacy First**: Direct device-to-device transfers, no cloud, no tracking
-- ⚡ **Lightning Fast**: Transfer at full network speed with optimized protocols
-- 🎮 **Steam Deck Ready**: Native support with touch controls and Gaming Mode integration
-- 🌐 **Cross Platform**: Seamless operation between macOS, Linux, and Steam Deck
-- 🎨 **Beautiful Interface**: Modern Material Design 3 with native platform integration
-- 🔧 **Open Source**: Fully open source with MIT license
+## Features
 
-## 🚀 Quick Start
+- **Zero-configuration discovery** -- mDNS/DNS-SD (`_warpdeck._tcp.local.`) finds peers automatically on your LAN
+- **End-to-end encrypted** -- TLS 1.3 for every transfer. No plaintext, ever.
+- **Trust-On-First-Use security** -- Approve a device once, it's trusted forever. No passwords. No accounts.
+- **Cross-platform** -- macOS, Linux, and Steam Deck with a dedicated 10-foot Gaming Mode UI
+- **Fast** -- Up to 1.9 GB/s LAN throughput with streaming I/O (files never fully buffered in memory)
+- **Desktop GUI + CLI** -- Flutter desktop app for everyday use, full CLI for headless/server/scripting
+- **Folders and queues** -- Send entire directory trees; transfers queue and process sequentially
+
+## How It Works
+
+```
+   Sender                           LAN                          Receiver
+     |                                                               |
+     |  1. DISCOVER  (mDNS broadcast: "_warpdeck._tcp.local.")       |
+     |-------------------------------------------------------------->|
+     |                                                               |
+     |  2. APPROVE   (first time only -- TOFU, like SSH)             |
+     |<--------------------------------------------------------------|
+     |               "Jesse's Mac wants to send files. Accept?"      |
+     |                                                               |
+     |  3. TRANSFER  (HTTPS/TLS 1.3 -- encrypted, streamed)         |
+     |=============================================================>|
+     |               game-mod.zip ===== 100% @ 450 MB/s             |
+     |                                                               |
+```
+
+1. **Discover**: Launch WarpDeck on two devices on the same network. They find each other instantly via mDNS.
+2. **Approve**: The first time two devices connect, the receiver sees an approval prompt. Accept once, and the device is permanently trusted (its certificate fingerprint is stored locally).
+3. **Transfer**: Drag files onto the device name (GUI) or use the CLI. Files stream over TLS 1.3 directly between devices. No relay. No cloud.
+
+## Architecture
+
+WarpDeck is three layers: a C++ engine, a Flutter GUI, and a CLI. The core handles all networking, crypto, and I/O. The frontends are thin.
+
+```
++----------------------------------------------------------+
+|                    warpdeck-gui (Flutter/Dart)            |
+|          Riverpod state / system tray / drag-drop        |
++------------------------------+---------------------------+
+                               |  dart:ffi
++------------------------------v---------------------------+
+|                     libwarpdeck (C++17)                   |
+|                                                          |
+|  +-------------+  +------------+  +-------------------+  |
+|  | mDNS        |  | HTTPS REST |  | Transfer Manager  |  |
+|  | Discovery   |  | Server +   |  | (state machine,   |  |
+|  | (DNS-SD)    |  | Client     |  |  file I/O, queue) |  |
+|  +-------------+  +------------+  +-------------------+  |
+|  +-------------+  +------------------------------------+ |
+|  | Security    |  | C-style FFI API (warpdeck.h)       | |
+|  | Manager     |  | opaque handle, callbacks, JSON     | |
+|  | (TLS, TOFU) |  +------------------------------------+ |
+|  +-------------+                                         |
++----------------------------------------------------------+
+
++----------------------------------------------------------+
+|                    warpdeck-cli (C++)                     |
+|         listen / send / list / config                    |
++----------------------------------------------------------+
+```
+
+| Layer | Language | Role |
+|-------|----------|------|
+| **libwarpdeck** | C++17 | Core engine: mDNS discovery, HTTPS REST server/client, TLS certificates, TOFU trust store, transfer state machine. Exposes a C-style FFI API via `warpdeck.h`. |
+| **warpdeck-gui** | Flutter/Dart | Desktop app with Riverpod state management, system tray integration, launch-at-startup. Communicates with libwarpdeck via `dart:ffi`. |
+| **warpdeck-cli** | C++ | Command-line interface for headless use, automation, and power users. Links directly against libwarpdeck. |
+
+## Security Model
+
+| Property | Implementation |
+|----------|---------------|
+| Key generation | RSA-2048 on first launch |
+| Certificates | Self-signed X.509 (no CA dependency) |
+| Transport | TLS 1.3 only (older protocols disabled) |
+| Authentication | Trust-On-First-Use with SHA-256 certificate fingerprinting |
+| Approval timeout | 60 seconds |
+| Network scope | Local network only -- no internet exposure |
+
+## Installation
 
 ### Download
 
-> 📦 **Fresh builds are automatically created** from every commit to the main branch via GitHub Actions CI/CD.
+| Platform | Format | Link |
+|----------|--------|------|
+| **macOS** | DMG | [Latest Release](https://github.com/deepc0py/WarpDeck/releases/latest) |
+| **Linux** | AppImage | [Latest Release](https://github.com/deepc0py/WarpDeck/releases/latest) |
+| **Steam Deck** | AppImage | [Latest Release](https://github.com/deepc0py/WarpDeck/releases/latest) |
 
-| Platform | Download | Size | Format |
-|----------|----------|------|--------|
-| **macOS** | [Download DMG](https://github.com/deepc0py/WarpDeck/releases/latest/download/WarpDeck-macOS.dmg) | ~25 MB | Universal Binary |
-| **Linux** | [Download AppImage](https://github.com/deepc0py/WarpDeck/releases/latest/download/WarpDeck.AppImage) | ~45 MB | Portable |
-| **Steam Deck** | [Download AppImage](https://github.com/deepc0py/WarpDeck/releases/latest/download/WarpDeck.AppImage) | ~45 MB | Optimized |
-
-### Installation
-
-#### macOS
-```bash
-# Download and install DMG
-curl -L -o WarpDeck.dmg https://github.com/deepc0py/WarpDeck/releases/latest/download/WarpDeck-macOS.dmg
-open WarpDeck.dmg
-# Drag WarpDeck to Applications folder
-```
-
-#### Linux
-```bash
-# AppImage (Universal)
-wget https://github.com/deepc0py/WarpDeck/releases/latest/download/WarpDeck.AppImage
-chmod +x WarpDeck.AppImage
-./WarpDeck.AppImage
-
-# Flatpak (Recommended)
-flatpak install flathub com.warpdeck.GUI
-```
-
-#### Steam Deck
-1. Switch to Desktop Mode
-2. Download the AppImage
-3. Make it executable and run
-4. Optional: Add to Steam as Non-Steam Game
-
-## 🎯 How It Works
-
-1. **Install WarpDeck** on your devices
-2. **Connect to the same network** (WiFi, etc.)
-3. **Devices auto-discover** each other
-4. **Select files** and choose destination
-5. **Transfer begins** directly between devices
-
-## 🏗️ Architecture
-
-WarpDeck consists of three main components:
-
-### 📚 libwarpdeck (C++)
-High-performance core library handling:
-- Peer discovery (mDNS/Bonjour)
-- Secure connections (TLS 1.3)
-- File transfer protocols
-- Cross-platform networking
-
-### 🖥️ CLI Application (C++)
-Command-line interface for:
-- Headless servers
-- Automation and scripting
-- Power users
-- Testing and debugging
-
-### 🎨 GUI Application (Flutter)
-Beautiful desktop interface featuring:
-- Material Design 3
-- Cross-platform consistency
-- Touch-optimized for Steam Deck
-- Real-time transfer progress
-- Automatic updates
-
-## 🔧 Development
-
-### Prerequisites
-- **Flutter SDK** 3.22.2+
-- **CMake** 3.15+
-- **C++17** compatible compiler
-- **Platform-specific tools**:
-  - macOS: Xcode Command Line Tools
-  - Linux: GTK3 development libraries
+Builds are automatically produced from every merge to `main` via GitHub Actions.
 
 ### Building from Source
 
-#### Quick Setup
-```bash
-# Clone the repository
-git clone https://github.com/deepc0py/WarpDeck.git
-cd WarpDeck
+**Prerequisites**: CMake 3.15+, C++17 compiler, Flutter SDK 3.22+, OpenSSL
 
-# Run the setup script (installs dependencies)
+<details>
+<summary><strong>macOS</strong></summary>
+
+```bash
 ./setup-dev.sh
-```
 
-#### Manual Build
-```bash
-# Build libwarpdeck
-cd libwarpdeck
-mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../../vcpkg/scripts/buildsystems/vcpkg.cmake ..
-make -j$(nproc)
+# Build the core library
+cd libwarpdeck && mkdir -p build && cd build
+cmake -DOPENSSL_ROOT_DIR=$(brew --prefix openssl@3) ..
+make -j$(sysctl -n hw.ncpu)
 
-# Build CLI
-cd ../../cli
-mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../../vcpkg/scripts/buildsystems/vcpkg.cmake ..
-make -j$(nproc)
-
-# Build GUI
+# Build and run the GUI
 cd ../../warpdeck-flutter/warpdeck_gui
 flutter pub get
-dart run build_runner build
-flutter build macos --release  # or linux
+dart run build_runner build --delete-conflicting-outputs
+flutter run -d macos
 ```
 
-#### Automated Builds
+</details>
 
-WarpDeck uses GitHub Actions for continuous integration and delivery:
+<details>
+<summary><strong>Linux</strong></summary>
 
-- **🔄 Continuous Integration**: Every pull request and commit is automatically built and tested
-- **📦 Automatic Releases**: New releases are automatically created from the main branch
-- **✅ Quality Checks**: Code formatting, analysis, and testing are enforced
-- **🚀 Fresh Downloads**: README download links always point to the latest builds
+```bash
+./setup-dev.sh
 
-The CI/CD pipeline builds for both macOS and Linux, running comprehensive tests and creating distributable packages automatically.
+# Build the core library
+cd libwarpdeck && mkdir -p build && cd build
+cmake -DCMAKE_TOOLCHAIN_FILE=../../vcpkg/scripts/buildsystems/vcpkg.cmake ..
+make -j$(nproc)
 
-### Project Structure
+# Build and run the GUI
+cd ../../warpdeck-flutter/warpdeck_gui
+flutter pub get
+dart run build_runner build --delete-conflicting-outputs
+flutter run -d linux
+```
+
+</details>
+
+## CLI Usage
+
+```bash
+warpdeck listen                           # Start daemon -- broadcast presence, receive files
+warpdeck list                             # One-shot peer discovery
+warpdeck send --to <device_id> file.txt   # Send files to a peer
+warpdeck config --set-name "My Mac"       # Set device name
+```
+
+## Project Structure
+
 ```
 WarpDeck/
-├── libwarpdeck/           # Core C++ library
-├── cli/                   # Command-line interface
-├── warpdeck-flutter/      # Flutter GUI application
-│   └── warpdeck_gui/
-├── website/               # Official website
-└── docs/                  # Documentation
+├── libwarpdeck/              # C++17 core library
+│   ├── include/              #   Public C API (warpdeck.h)
+│   ├── src/                  #   Implementation
+│   └── CMakeLists.txt
+├── warpdeck-cli/             # Command-line interface
+├── warpdeck-flutter/
+│   └── warpdeck_gui/         # Flutter desktop app
+├── third_party/              # Vendored deps (mjansson/mdns)
+├── scripts/                  # Build & deploy scripts
+└── .github/workflows/        # CI/CD
 ```
 
-## 📊 Performance
+## Dependencies
 
-WarpDeck achieves excellent performance across all metrics:
+**C++**: OpenSSL, [cpp-httplib](https://github.com/yhirose/cpp-httplib), [nlohmann/json](https://github.com/nlohmann/json), [mjansson/mdns](https://github.com/mjansson/mdns)
 
-- **Memory Usage**: < 50MB baseline, minimal leaks
-- **Transfer Speed**: Up to 1.9GB/s local network throughput
-- **UI Responsiveness**: < 4ms average response time
-- **Network Discovery**: 19 peers/second discovery rate
-- **Battery Efficiency**: 9.5+ hours on Steam Deck
+**Flutter**: flutter_riverpod, ffi, window_manager, system_tray, file_picker, google_fonts
 
-## 🎮 Steam Deck Optimization
+## CI/CD
 
-WarpDeck is specially optimized for Steam Deck:
+GitHub Actions builds on every push to `main`, targeting both macOS and Ubuntu. Releases are tagged automatically as `v{date}-{sha}` and produce macOS DMG, Linux AppImage, and CLI binaries.
 
-- **Touch Interface**: Large touch targets and gestures
-- **Gamepad Navigation**: Full controller support
-- **Gaming Mode**: Steam library integration
-- **Battery Awareness**: Power-efficient operation
-- **7" Display**: Optimized for handheld screen
-- **Haptic Feedback**: Controller vibration support
+## Steam Deck
 
-## 🔐 Security
+WarpDeck includes a dedicated Gaming Mode UI built for the 10-foot experience:
 
-WarpDeck prioritizes security and privacy:
+- Large touch targets and gamepad-navigable focus system
+- Steam color theme and controller button prompts
+- Automatic detection of gamescope session to switch UI modes
+- Works in both Desktop Mode (standard GUI) and Gaming Mode (controller UI)
 
-- **TLS 1.3 Encryption**: All transfers are encrypted
-- **Local Network Only**: No internet connectivity required
-- **No Data Collection**: Zero telemetry or tracking
-- **Open Source**: Fully auditable codebase
-- **Certificate Pinning**: Prevent man-in-the-middle attacks
+## Contributing
 
-## 🤝 Contributing
-
-We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for detailed information.
-
-### Quick Start for Contributors
-1. Fork the repository
-2. Run `./setup-dev.sh` to set up your environment
+1. Fork the repo
+2. Run `./setup-dev.sh`
 3. Create a feature branch
-4. Make your changes and test them
-5. Submit a pull request
+4. Make changes, test locally
+5. Open a pull request
 
-All pull requests are automatically built and tested by our CI/CD pipeline.
+All PRs are built and tested automatically.
 
-### Areas for Contribution
-- 🐛 Bug fixes and testing
-- ✨ New features and enhancements
-- 📖 Documentation improvements
-- 🌍 Internationalization
-- 🎨 UI/UX improvements
-- 🔧 Platform-specific optimizations
+## License
 
-## 📖 Documentation
-
-- **[Quick Start Guide](docs/QUICK_START.md)**: Get started in 5 minutes
-- **[User Manual](docs/USER_MANUAL.md)**: Complete feature documentation
-- **[Steam Deck Guide](docs/STEAM_DECK.md)**: Installation and optimization
-- **[API Reference](docs/API.md)**: Developer documentation
-- **[Deployment Guide](warpdeck-flutter/warpdeck_gui/DEPLOYMENT.md)**: Building and distribution
-
-## 🌟 Roadmap
-
-### Version 1.1 (Q1 2025)
-- [ ] Windows support
-- [ ] Transfer resume/pause
-- [ ] Bandwidth limiting
-- [ ] Transfer history
-
-### Version 1.2 (Q2 2025)
-- [ ] Mobile apps (Android/iOS)
-- [ ] QR code pairing
-- [ ] Cloud bridge mode
-- [ ] Advanced permissions
-
-### Version 2.0 (Q3 2025)
-- [ ] P2P mesh networking
-- [ ] End-to-end encryption
-- [ ] Plugin system
-- [ ] Advanced UI themes
-
-## 📞 Support
-
-- **🐛 Bug Reports**: [GitHub Issues](https://github.com/deepc0py/WarpDeck/issues)
-- **💬 Discussions**: [GitHub Discussions](https://github.com/deepc0py/WarpDeck/discussions)
-- **📖 Documentation**: [Official Docs](https://warpdeck.dev/docs)
-- **💌 Contact**: [warpdeck@example.com](mailto:warpdeck@example.com)
-
-## 📄 License
-
-WarpDeck is released under the [MIT License](LICENSE). See the license file for details.
-
-## 🙏 Acknowledgments
-
-- **Flutter Team**: For the excellent cross-platform framework
-- **Material Design**: For the beautiful design system
-- **Steam Deck Community**: For feedback and testing
-- **Open Source Community**: For libraries and contributions
-
----
-
-<div align="center">
-
-**Built with ❤️ for the open source community**
-
-[Website](https://warpdeck.dev) • [Download](https://github.com/deepc0py/WarpDeck/releases) • [Documentation](https://warpdeck.dev/docs) • [Community](https://github.com/deepc0py/WarpDeck/discussions)
-
-</div>
-
----
-
-# Technical Specification and Product Requirements Document
-
-## **Part I: Product Definition and System Architecture**
-
-This document provides the complete Product Requirements Document (PRD) and Technical Specification for **WarpDeck**, a cross-platform, peer-to-peer file sharing application. The intended audience for this document is the engineering team responsible for implementation, providing a definitive blueprint for development.
-
-### **1.1. Vision, Mission, and Guiding Principles**
-
-#### **1.1.1. Vision Statement**
-
-To create the most seamless, reliable, and secure method for wireless file sharing between the macOS and Steam Deck ecosystems.
-
-#### **1.1.2. Mission Statement**
-
-To build a cross-platform utility, WarpDeck, that eliminates the friction of transferring files between a user's primary computer (Mac) and their handheld gaming device (Steam Deck), making the workflow as intuitive and effortless as Apple's AirDrop. The application will bridge the gap between these two distinct platforms, enhancing user productivity and convenience for tasks such as transferring game modifications, ROMs, screenshots, and other media.
-
-#### **1.1.3. Guiding Principles**
-
-The development of WarpDeck will be governed by four core principles:
-
-* **Simplicity:** The user experience must be predicated on the "it just works" philosophy. Device discovery shall be automatic and require no manual configuration such as IP address entry. File transfers should be initiated with minimal user interaction, such as a simple drag-and-drop gesture. The application must abstract away all underlying network complexity.1
-* **Security:** Security is a foundational requirement, not an optional feature. All data transfers must be protected with robust, modern, end-to-end encryption. Users must have clear, explicit control over device discovery and transfer permissions. The protocol will be designed to prevent unauthorized access and man-in-the-middle attacks within the local network context.3
-* **Performance:** The protocol and application must be optimized for high-speed transfer of large files over local Wi-Fi networks. Given that common use cases include transferring multi-gigabyte game files, the architecture must prioritize low latency and high throughput, leveraging efficient I/O operations and modern network protocols.2
-* **Platform-Nativeness:** While leveraging cross-platform technologies for development efficiency, the application must feel native to each target operating system. It must respect the distinct UI/UX paradigms of macOS and Steam Deck (in both its Desktop and Gaming modes) and integrate gracefully with platform-specific features and constraints, such as the macOS App Sandbox and the SteamOS immutable filesystem.6
-
-### **1.2. User Epics & Stories**
-
-The following user epics and stories define the core functional requirements from a user-centric perspective.
-
-#### **Epic 1: Effortless Sending from macOS**
-
-* **Story 1.1:** As a Mac user, I want to send a file or a group of files to my Steam Deck by dragging them from Finder and dropping them onto the WarpDeck application window, so that I can quickly transfer game assets without navigating complex menus.
-* **Story 1.2:** As a Mac user, I want to be able to right-click a file in Finder and use a "Share" or "Send with WarpDeck" option in the context menu to initiate a transfer, providing a workflow integrated into the operating system.
-* **Story 1.3:** As a Mac user, I want to see a clear list of available devices (my Steam Deck) within the WarpDeck app, with visual indicators of their status (e.g., available, connected, transferring), so I can confidently select the correct destination.
-
-#### **Epic 2: Seamless Receiving on Steam Deck**
-
-* **Story 2.1:** As a Steam Deck user in Desktop Mode, I want to receive a file from my Mac and have it automatically saved to a pre-configured folder (defaulting to \~/Downloads), so I can access it immediately without extra steps.
-* **Story 2.2:** As a Steam Deck user in Gaming Mode, I want to receive a clear, non-intrusive on-screen notification for an incoming file transfer, so I am aware of the request without it disrupting my current activity.
-* **Story 2.3:** As a Steam Deck user in Gaming Mode, I want to be able to accept or decline an incoming transfer using only my controller buttons (e.g., 'A' to accept, 'B' to decline), so I do not need to switch to Desktop Mode or connect a mouse.
-
-#### **Epic 3: Secure & Trusted Connections**
-
-* **Story 3.1:** As a user on either platform, the very first time I attempt to transfer a file between two of my devices, I want the receiving device to display a confirmation prompt asking for my approval, so that I can prevent unknown or unauthorized devices from connecting.
-* **Story 3.2:** As a user, after I have approved a device once, I want all future transfers from that same, trusted device to be accepted automatically without a prompt, so my workflow is streamlined for my personal devices.
-* **Story 3.3:** As a user, I want a simple interface in the settings to view and manage my list of trusted devices, with the ability to "forget" or revoke trust from a device if needed.
-
-### **1.3. High-Level System Architecture**
-
-WarpDeck will be implemented using a modular architecture that separates the core logic from the user interface. This approach maximizes code reuse, enhances maintainability, and allows for flexible UI development. The system comprises three primary components.
-
-**System Components:**
-
-1. **libwarpdeck (C++ Core Logic):** A self-contained, portable, static C++ library that encapsulates all non-UI logic. This includes device discovery, network protocol implementation (server and client), cryptographic functions (TLS and certificate management), file I/O operations, and transfer session management. This library will be the "engine" of WarpDeck, designed to be compiled and linked on both macOS and Linux.
-2. **WarpDeck CLI:** A lightweight C++ executable that directly links against libwarpdeck. It provides a full-featured command-line interface for all core functionalities, including discovery, sending files, and listening for incoming transfers. The CLI will serve as the initial proof-of-concept and a powerful tool for testing, automation, and advanced users.
-3. **WarpDeck GUI (Flutter):** A single, cross-platform application built with the Flutter framework and the Dart programming language. This application will contain the complete user interface logic for both macOS and Steam Deck, communicating with the C++ core via a Foreign Function Interface (FFI).
-
-The selection of a C++ core with a Flutter front-end is a strategic decision driven by the unique requirements of the target platforms. A shared C++ core ensures maximum performance for network and file operations and allows complex, low-level logic to be written once and deployed everywhere.8 This is essential for achieving the high-performance goals of the project.
-
-For the GUI, Flutter presents a compelling advantage over developing separate native applications. The Steam Deck introduces a complex "three-UI" challenge: a standard desktop UI for macOS, a similar desktop UI for Steam Deck's KDE Plasma mode, and a completely distinct, controller-driven "10-foot" UI for Steam Deck's Gaming Mode.9
-
-Developing and maintaining three separate native UIs (e.g., SwiftUI for macOS, Qt for Linux Desktop, and a custom renderer for Gaming Mode) would be resource-prohibitive and significantly increase complexity.12 Flutter, with its single Dart codebase, can target all three environments from one project.14 It enables the creation of a standard, Material Design-based desktop UI and a completely custom, controller-friendly UI within the same application. The application can conditionally render the appropriate UI at runtime by detecting its environment (e.g., the presence of a "gamescope" session on Steam Deck).
-
-The performance of Flutter is near-native, especially for UI rendering, due to its use of the Skia graphics engine and AOT (Ahead-of-Time) compilation of Dart code.16 For a utility application like WarpDeck, where the most intensive work (file transfer) is handled by the native C++ core, any performance overhead from the Flutter UI layer is negligible compared to the substantial gains in development velocity and code maintainability.
-
-The integration between the Flutter UI and the C++ core will be achieved using Dart's dart:ffi library. The C++ library will expose a stable, C-style API in a public header file (warpdeck.h). The ffigen tool will be used to automatically parse this header and generate the corresponding Dart bindings, creating a robust, type-safe, and low-overhead bridge between the two layers.18 This automated approach is more reliable and maintainable than manual FFI binding implementation.
-
-## **Part II: WarpDeck Network Protocol Specification**
-
-The WarpDeck Protocol (WDP) is a custom, application-layer protocol designed for secure and efficient peer-to-peer file transfer over a local area network (LAN). It is a hybrid protocol that leverages established standards for discovery and a simple, modern web-based stack for control and data transfer.
-
-### **2.1. Protocol Overview & Rationale**
-
-WDP consists of three distinct phases: Discovery, Handshake & Authentication, and File Transfer.
-
-1. **Discovery:** Device discovery is handled by **Multicast DNS (mDNS) paired with DNS-Service Discovery (DNS-SD)**. This is the same technology stack that powers Apple's Bonjour and the Linux Avahi daemon.21 This choice provides a standardized, robust, and zero-configuration discovery mechanism that is natively supported or easily implemented on both macOS and Arch Linux. It is more reliable than custom UDP broadcast schemes, which can be less efficient and more prone to being dropped by network hardware or firewalls.23
-2. **Handshake & Transfer:** All direct device-to-device communication occurs over **HTTPS (HTTP over TLS 1.3)**. Each WarpDeck instance runs an embedded RESTful API server. This approach, inspired by the simplicity of LocalSend's protocol 24, is well-suited for file transfer and status updates. It is more straightforward to implement and debug than more complex RPC frameworks like gRPC/Protobuf used by Warpinator, which are optimized for structured data exchange rather than bulk binary transfer.26
-3. **Security:** Security is established through **TLS 1.3** for transport-level encryption. Since there is no central certificate authority (CA), device authenticity is managed via a **"Trust On First Use" (TOFU)** model. Each device generates a self-signed certificate, and users manually verify and approve the certificate's fingerprint upon the first connection, establishing a durable trust relationship.29
-
-### **2.2. Phase 1: Device Discovery (mDNS / DNS-SD)**
-
-Each WarpDeck application instance, upon launch, must register and broadcast a service on the local network using mDNS/DNS-SD. It must also simultaneously browse for other instances of the same service.
-
-* **Implementation:**
-  * **macOS:** The native Bonjour NetService and NetServiceBrowser APIs from the Foundation framework will be used.
-  * **SteamOS (Arch Linux):** The avahi-client and avahi-client-glib libraries will be used to interact with the system's Avahi daemon.22 The application will have
-    avahi as a dependency.
-* **Service Definition:**
-  * **Service Type:** \_warpdeck.\_tcp.local.
-  * **Instance Name:** A user-configurable, human-readable name for the device (e.g., "Gabe's Steam Deck"). This name will be displayed in the UI of other devices.
-  * **Port:** The TCP port number on which the local WarpDeck HTTPS REST server is listening. This port should be dynamically chosen from the ephemeral range if the default is unavailable.
-* **Service Metadata (TXT Record):** The DNS-SD TXT record is critical for an efficient handshake, as it allows peers to exchange essential metadata without initiating a full TCP/TLS connection. The TXT record will contain a set of key-value pairs. This metadata must include a unique device identifier, platform information for UI rendering, and the certificate fingerprint for the TOFU security model. This pre-emptive sharing of the fingerprint is a key optimization, allowing a client to know if it already trusts a discovered peer before making any network connection.
-  Table 2.2.1: mDNS Service TXT Record Specification
-  | Key | Type | Description | Example Value |
-  | :--- | :--- | :--- | :--- |
-  | v | String | Protocol version string (Major.Minor). Ensures compatibility between clients. | 1.0 |
-  | id | String | A persistent, unique UUID (v4) for the device, generated on first launch and stored locally. Used to reliably identify a device even if its name changes. | a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d |
-  | name | String | User-configurable device name, UTF-8 encoded. | John's MacBook Pro |
-  | platform | String | Operating system identifier. Enum: macos, steamdeck. Used by the UI to display the correct device icon. | macos |
-  | port | Integer | The TCP port for the HTTPS REST API server. | 54321 |
-  | fp | String | The SHA-256 fingerprint (hex-encoded) of the device's self-signed X.509 TLS certificate. This is essential for the TOFU security model. | A1B2C3D4...F9E8 |
-
-### **2.3. Phase 2: Handshake & Authentication (TLS \+ TOFU)**
-
-The security of WarpDeck relies on strong encryption and explicit user consent for establishing trust.
-
-* **Certificate Generation and Storage:**
-  * On its first launch, libwarpdeck will generate a 2048-bit RSA key pair and a corresponding self-signed X.509 certificate.
-  * The certificate's Common Name (CN) should be set to the device's unique ID (id from the TXT record).
-  * The certificate and its private key must be stored securely in a location appropriate for the platform (e.g., macOS Keychain, or an encrypted file within the app's sandboxed data directory on Linux).
-* **TLS Handshake:**
-  * All TCP connections must be upgraded to TLS v1.3 immediately. Older protocols (SSLv3, TLS 1.0, 1.1, 1.2) must be disabled.
-  * The cipher suite configuration must prioritize modern, authenticated encryption with associated data (AEAD) ciphers, specifically those using AES-GCM. Weak and obsolete ciphers (e.g., NULL, EXPORT, RC4, 3DES) must be explicitly disabled.4
-* Trust On First Use (TOFU) Workflow:
-  This workflow is designed to be both secure and user-friendly, abstracting the complexity of certificate verification into a simple, one-time user action.
-  1. **Discovery:** User A's device (Sender) discovers User B's device (Receiver) via mDNS and displays its name and platform in the UI. The Sender's app retrieves the Receiver's id and fp from the TXT record.
-  2. **Trust Check (Pre-connection):** The Sender checks its local trust store (a simple database mapping device ids to trusted fps) for an entry matching the Receiver's id.
-  3. **Transfer Initiation:** User A initiates a transfer to the Receiver.
-  4. **First-Time Connection Flow:**
-     * If the Receiver's id is **not** in the Sender's trust store, the Sender's UI shows a "Connecting..." state.
-     * The Sender initiates a TLS handshake with the Receiver. The Sender's TLS client must be configured to **allow self-signed certificates** but must **verify that the fingerprint of the certificate presented by the server matches the fp value received in the mDNS TXT record**. This prevents a basic man-in-the-middle attack where an attacker spoofs the mDNS record but cannot produce a certificate with a matching fingerprint.
-     * Upon successful connection, the Sender makes the initial API call (e.g., POST /api/v1/transfer/request).
-     * The Receiver's API server receives the request. It extracts the client's certificate fingerprint from the TLS session and checks its own trust store. It is a new device.
-     * The Receiver's UI presents a clear, unambiguous prompt to User B: "**'' wants to send you files. Accept?**" with "Accept" and "Decline" options. This prompt must be fully navigable with a controller in Steam Deck's Gaming Mode.33
-     * If User B selects "Accept," the Receiver's API responds with a success code (e.g., 202 Accepted). Both the Sender and Receiver then add the other device's id and fp to their respective local trust stores.
-     * If User B selects "Decline," the API responds with an error code (e.g., 403 Forbidden), and the connection is terminated.
-  5. **Trusted Connection Flow:**
-     * If the Receiver's id **is** in the Sender's trust store, the Sender verifies that the fp from the mDNS record matches the stored fingerprint.
-     * The Sender connects and the Receiver's API server verifies the client certificate fingerprint against its trust store.
-     * Since both parties trust each other, the transfer request is processed automatically without any user prompt on the receiving end. The file transfer begins immediately upon initiation by the sender.
-
-### **2.4. Phase 3: File Transfer (REST API)**
-
-The file transfer process is managed by a RESTful API. This design avoids the brittleness of sending large files in a single request, providing a mechanism for metadata exchange, progress tracking, and error handling.
-
-* **API Server:** The embedded HTTPS server in libwarpdeck listens on the port advertised via mDNS. It must be capable of handling multiple concurrent connections.
-* **API Design Rationale:** A simple POST /upload with the entire file in the request body is unsuitable for the large files WarpDeck is designed to handle. Such an approach is not resumable, provides no mechanism for the receiver to check for available disk space before the transfer starts, and offers no granular progress feedback.34 The chosen two-stage protocol (request metadata, then send data) addresses these shortcomings. The sender first announces its intent to send a batch of files, allowing the receiver to approve the transfer and prepare for it. The actual file data is then sent in a separate request.
-  Table 2.4.1: WarpDeck REST API Endpoints (Version 1.0)
-  | Endpoint | Method | Description | Request Body | Success Response | Error Responses |
-  | :--- | :--- | :--- | :--- | :--- | :--- |
-  | /api/v1/info | GET | Health check and device information endpoint. Used to verify a peer is responsive. | (none) | 200 OK with DeviceInfo JSON body. | 500 Internal Server Error |
-  | /api/v1/transfer/request | POST | Initiates a file transfer request. Contains metadata for all files in the batch. The receiver should verify available space and, if the sender is untrusted, prompt the user for confirmation. | TransferRequest JSON body. | 202 Accepted with TransferSession JSON body. The transfer\_id is used in subsequent calls. | 400 Bad Request, 403 Forbidden (user declined), 507 Insufficient Storage |
-  | /api/v1/transfer/{transfer\_id}/{file\_index} | POST | Uploads a single file associated with an approved transfer session. The file\_index corresponds to the file's position in the initial TransferRequest array. The entire file is sent as the request body. | Raw binary data of the file. Content-Type header should be application/octet-stream. Content-Length must be accurate. | 200 OK (empty body). | 404 Not Found (invalid transfer\_id), 409 Conflict (file already received), 500 Internal Server Error |
-  | /api/v1/transfer/{transfer\_id} | GET | (Optional for v1.0, for future use) Gets the current status of a transfer session, allowing for progress polling. | (none) | 200 OK with TransferStatus JSON body. | 404 Not Found |
-
-### **2.5. Data Structures & Payloads (JSON Schemas)**
-
-All API payloads will use the application/json content type.
-
-* **DeviceInfo (Response for GET /info)**
-  * Description: Provides basic information about the device.
-  * Schema:
-    JSON
-    {
-      "id": "string (uuid)",
-      "name": "string",
-      "platform": "string (enum: 'macos', 'steamdeck')",
-      "protocol\_version": "string"
-    }
-
-* **FileMetadata (Object within TransferRequest)**
-  * Description: Metadata for a single file to be transferred.
-  * Schema:
-    JSON
-    {
-      "name": "string",
-      "size": "integer (bytes)",
-      "hash": "string (sha256 of file content, optional)"
-    }
-
-* **TransferRequest (Request body for POST /transfer/request)**
-  * Description: An array of files the sender wishes to transfer.
-  * Schema:
-    JSON
-    {
-      "files": \[
-        { "$ref": "\#/definitions/FileMetadata" }
-      \]
-    }
-
-* **TransferSession (Response for POST /transfer/request)**
-  * Description: Acknowledges the transfer request and provides a unique ID for the session.
-  * Schema:
-    JSON
-    {
-      "transfer\_id": "string (uuid)",
-      "status": "string (enum: 'pending\_user\_acceptance', 'ready\_to\_receive')",
-      "expires\_at": "string (ISO 8601 timestamp)"
-    }
-
-* **ErrorResponse (Generic error body)**
-  * Description: A standardized error response.
-  * Schema:
-    JSON
-    {
-      "error\_code": "string (e.g., 'INSUFFICIENT\_STORAGE', 'USER\_DECLINED')",
-      "message": "string (human-readable error description)"
-    }
-
-## **Part III: Core Logic Library (libwarpdeck) \- C++ Specification**
-
-The libwarpdeck library is the heart of the WarpDeck application. It is a modern, cross-platform C++17 static library responsible for implementing the WarpDeck Protocol and all associated business logic. It is designed to be completely headless and controlled via a well-defined public API, making it suitable for integration with any UI front-end.
-
-### **3.1. Library Architecture & Modules**
-
-The library will be architected into several distinct, cohesive modules, each with a specific responsibility. This modular design promotes separation of concerns and simplifies testing and maintenance.
-
-* **Dependencies:**
-  * **Networking:** Boost.Asio will be used for asynchronous, cross-platform socket programming and thread pool management.36
-  * **HTTP Server/Client:** A lightweight, header-only C++ HTTP/S library such as cpp-httplib will be used to implement the REST API. It will be integrated with Boost.Asio for networking and OpenSSL for TLS.
-  * **Cryptography:** OpenSSL will be used for all TLS functionality, certificate generation, and hashing algorithms.37
-  * **mDNS/DNS-SD:** Platform-specific libraries will be used. On macOS, this will link against the native Bonjour/dns\_sd framework. On Linux, it will link against libavahi-client.22
-  * **Build System:** CMake will be the canonical build system for libwarpdeck, managing all sources, dependencies, and build configurations for target platforms.
-* **Core Modules:**
-  * **DiscoveryManager:** This module is responsible for both broadcasting the local device's presence and discovering other peers on the network. It will run in a dedicated background thread. On macOS, it will wrap NetService and NetServiceBrowser. On Linux, it will wrap the asynchronous avahi-client APIs. It maintains an internal list of discovered peers and their metadata, notifying the application layer via callbacks when the list changes.
-  * **APIServer:** This module instantiates and runs the embedded HTTPS server. It defines the REST API endpoints specified in Part II, parses incoming requests, and routes them to the appropriate handler in the TransferManager. It manages the TLS context, loading the device's self-signed certificate and private key.
-  * **APIClient:** A thin wrapper around the HTTP client library for making outgoing HTTPS requests to other WarpDeck peers. It handles the construction of requests and parsing of responses for all defined API endpoints.
-  * **TransferManager:** This is the state machine for all file transfers. It manages active send and receive sessions, identified by their transfer\_id. For receiving, it handles file I/O, writing incoming data to temporary files before moving them to the final destination upon completion. For sending, it reads files from disk and streams them to the APIClient. It is also responsible for calculating and reporting transfer progress.
-  * **SecurityManager:** This module manages all cryptographic assets and trust decisions. Its responsibilities include:
-    * Generating the initial RSA key pair and self-signed X.509 certificate on first launch.
-    * Securely storing and retrieving the private key and certificate from the platform's secure storage.
-    * Managing the local trust store, which is a simple database (e.g., SQLite or a protected JSON file) that maps trusted peer device UUIDs to their certificate fingerprints.
-  * **CallbackInterface:** This is the primary bridge to the UI layer. It is an abstract C++ class (or a C struct of function pointers) that defines a set of virtual functions corresponding to asynchronous events (e.g., onPeerDiscovered, onPeerLost, onIncomingTransferRequest, onTransferProgressUpdate, onTransferCompleted). The UI layer (e.g., the Flutter app) provides a concrete implementation of this interface to receive notifications from the core library.
-
-### **3.2. Public API Definition (C-Style for FFI/Interop)**
-
-To ensure maximum portability and ease of integration with foreign function interfaces in languages like Dart and Swift, the public API of libwarpdeck will be exposed as a pure C-style interface. This design choice avoids C++ name mangling and the complexities of marshalling class objects across language boundaries. The core C++ objects will be hidden behind an opaque pointer (WarpDeckHandle), a standard and robust pattern for creating language-agnostic library bindings.8
-
-All asynchronous events from the library to the client application will be handled via a callback mechanism. The client provides a struct of function pointers during initialization, which the library will invoke on the appropriate thread when events occur. Data will be passed as primitive types or serialized JSON strings to simplify marshalling.
-
-The entire public API will be defined in a single header file, warpdeck.h.
-
-Table 3.2.1: libwarpdeck Public API Reference (warpdeck.h)
-| Function Signature | Description |
-| :--- | :--- |
-| typedef struct Callbacks {... } Callbacks; | A struct containing function pointers for all event callbacks (e.g., void (\*on\_peer\_discovered)(const char\* peer\_json);). |
-| WarpDeckHandle\* warpdeck\_create(const Callbacks\* cbs, const char\* config\_dir); | Initializes the library, providing callback implementations and a path to a writable directory for configuration and trust store files. Returns an opaque handle to the library instance. |
-| void warpdeck\_destroy(WarpDeckHandle\* handle); | Shuts down all services, releases resources, and invalidates the handle. |
-| int warpdeck\_start(WarpDeckHandle\* handle, const char\* device\_name, int desired\_port); | Starts the discovery manager and the API server on the specified port (or an ephemeral one if 0). Returns the actual port number used. |
-| void warpdeck\_stop(WarpDeckHandle\* handle); | Stops the discovery manager and API server. |
-| void warpdeck\_set\_device\_name(WarpDeckHandle\* handle, const char\* new\_name); | Updates the device's broadcasted name. |
-| void warpdeck\_initiate\_transfer(WarpDeckHandle\* handle, const char\* device\_id, const char\* files\_json); | Begins a file transfer to a discovered peer, identified by its unique ID. files\_json is a serialized array of FileMetadata objects. |
-| void warpdeck\_respond\_to\_transfer(WarpDeckHandle\* handle, const char\* transfer\_id, bool accept); | Called by the UI to accept or reject an incoming transfer request identified by its transfer\_id. |
-| void warpdeck\_cancel\_transfer(WarpDeckHandle\* handle, const char\* transfer\_id); | Cancels an in-progress transfer, either sending or receiving. |
-| const char\* warpdeck\_get\_trusted\_devices(WarpDeckHandle\* handle); | Returns a JSON string representing a list of all known trusted devices. The caller is responsible for freeing the returned string. |
-| void warpdeck\_remove\_trusted\_device(WarpDeckHandle\* handle, const char\* device\_id); | Removes a device from the local trust store. |
-
-### **3.3. Threading and Asynchronicity Model**
-
-The library must operate without blocking the main UI thread of the host application. It will employ a robust, asynchronous, multi-threaded architecture.
-
-* **Main Thread Safety:** All public API functions (warpdeck\_\*) must be thread-safe and non-blocking. They will immediately return after scheduling work on a background thread.
-* **Background Worker Threads:** An internal thread pool, managed by Boost.Asio's io\_context, will be used to execute all long-running and I/O-bound tasks. This includes:
-  * Running the mDNS discovery loop.
-  * Handling incoming HTTP requests.
-  * Performing file read/write operations during transfers.
-* **Callback Dispatching:** All callbacks into the client application's code must be dispatched on the main application thread. The library will need a mechanism (provided by the host application during initialization) to queue a function for execution on the main thread to ensure UI updates are thread-safe.
-
-### **3.4. Build & Dependency Management**
-
-A clean and reproducible build process is essential for cross-platform development.
-
-* **Build System:** CMake is the designated build system. The CMakeLists.txt file will define the libwarpdeck static library target and handle platform-specific compilation flags and library linking.
-* **Dependency Management:** To simplify setup for developers, dependencies will be managed as follows:
-  * **Boost & OpenSSL:** It is recommended to use a package manager like vcpkg or Conan to acquire these dependencies. The CMake project will be configured to find packages installed by these tools.
-  * **cpp-httplib:** As a header-only library, it can be included directly in the project source tree or as a Git submodule.
-  * **avahi:** This is a system-level dependency on Linux and will be linked dynamically using pkg-config in the CMake configuration.
-* **Compilation Output:** The build process will produce a single static library (libwarpdeck.a on macOS/Linux) and the public header file (warpdeck.h). This pair constitutes the complete SDK for UI developers.
-
-## **Part IV: Command-Line Interface (CLI) Specification**
-
-The WarpDeck CLI is the first functional implementation of the libwarpdeck core. It serves as a proof-of-concept, a testing tool, and a powerful utility for users who prefer a terminal-based workflow.
-
-### **4.1. Functional Requirements**
-
-The CLI application must provide the following capabilities:
-
-1. **Listen Mode:** Run as a persistent background or foreground process to discover peers and listen for incoming file transfer requests.
-2. **Device Discovery:** List all other active WarpDeck instances currently discoverable on the local network.
-3. **File Sending:** Initiate and execute the transfer of one or more files to a specific, discovered peer.
-4. **Interactive Confirmation:** Prompt the user to interactively accept or reject incoming transfer requests, displaying the sender's name and the list of files.
-5. **Configuration:** Allow the user to set and persist the device's broadcast name.
-
-### **4.2. Command-Line Syntax**
-
-The CLI will be invoked through a single executable, warpdeck. Its behavior will be controlled by subcommands and options.
-
-* **warpdeck listen**
-  * **Description:** Starts the application in daemon/listening mode. It will continuously broadcast its presence and listen for incoming connections. Discovered peers and transfer events will be logged to standard output.
-  * **Options:**
-    * \--name \<"Device Name"\>: Temporarily override the broadcast device name for this session.
-    * \--path \<"/path/to/save"\>: Set the destination directory for received files for this session.
-* **warpdeck list**
-  * **Description:** Performs a one-shot discovery and prints a list of all currently visible peers on the network, then exits.
-  * **Output Format:** A table displaying Device Name and Device ID.
-* **warpdeck send \--to \<device\_id\> \<file1\_path\> \[\<file2\_path\>...\]**
-  * **Description:** Sends one or more specified files or directories to a target device.
-  * **Arguments:**
-    * \--to \<device\_id\>: (Required) The unique ID of the target device, as obtained from warpdeck list.
-    * \<file\_path\>: One or more paths to the files or directories to be sent.
-* **warpdeck config \--set-name \<"New Device Name"\>**
-  * **Description:** Sets the device name that will be stored persistently and used for future broadcasts.
-
-### **4.3. User Interaction Flow Examples**
-
-#### **Example 1: Sending a File**
-
-1. User on Machine A (macOS) lists available devices:
-   Bash
-   $ warpdeck list
-
-   Discovered Devices:
-   \----------------------------------------------------------------------
-   Name                 ID
-   \----------------------------------------------------------------------
-   Gabe's Steam Deck    a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
-
-2. User on Machine A sends a file to the Steam Deck:
-   Bash
-   $ warpdeck send \--to a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d./game-mod.zip
-
-   \[INFO\] Requesting transfer of 'game-mod.zip' (150.3 MB) to "Gabe's Steam Deck"...
-   \[INFO\] "Gabe's Steam Deck" accepted the transfer.
-   \[INFO\] Sending game-mod.zip \[====================\>\] 100% 150.3 MB/s
-   \[INFO\] Transfer complete.
-
-#### **Example 2: Receiving a File**
-
-1. User on Machine B (Steam Deck) is running the listener:
-   Bash
-   $ warpdeck listen
-
-   \[INFO\] WarpDeck listening as "Gabe's Steam Deck"...
-   \[INFO\] Discovered peer: "John's MacBook Pro" (ID: f0e9d8c7-...)
-
-2. When Machine A initiates a transfer, a prompt appears on Machine B's terminal:
-   Bash
-   Incoming transfer request from "John's MacBook Pro":
-    \- game-mod.zip (150.3 MB)
-
-   Accept? (y/n): y
-
-   \[INFO\] Receiving game-mod.zip... \[====================\>\] 100%
-   \[INFO\] Transfer complete. File saved to /home/deck/Downloads/game-mod.zip.
-
-## **Part V: macOS GUI Application Specification**
-
-This section details the requirements and design for the WarpDeck graphical user interface application for the macOS platform.
-
-### **5.1. Architecture**
-
-* **Framework:** The application will be developed using the **Flutter framework** and the Dart programming language.
-* **Core Integration:** The Flutter application will interface with the C++ libwarpdeck static library. This integration will be achieved through Dart's Foreign Function Interface (dart:ffi).
-* **Binding Generation:** The package:ffigen tool will be used to automatically generate the Dart bindings by parsing the warpdeck.h public C header file. This ensures a type-safe, low-maintenance bridge between the Dart UI layer and the C++ core logic.19
-* **Packaging and Distribution:** The final deliverable will be a standard macOS Application Bundle (.app). For distribution, this bundle must be **codesigned** with a valid Apple Developer ID certificate and **notarized** by Apple. This is a mandatory requirement for running on modern macOS versions without prohibitive security warnings.38
-
-### **5.2. UI/UX Design & Wireframes**
-
-The user interface will be clean, minimalist, and adhere closely to Apple's Human Interface Guidelines (HIG) to provide a familiar and intuitive experience for Mac users.6
-
-* **Main Window:**
-  * **Layout:** A single, simple window will be the primary interface. The window will display a vertically scrolling list of discovered peer devices.
-  * **Device List Item:** Each item in the list will represent a discovered device and will contain:
-    * A platform icon (e.g., a Steam Deck logo or a generic computer icon for macOS).
-    * The device's user-configured name (e.g., "My Steam Deck").
-    * A status indicator (e.g., a colored dot or text: "Available", "Connecting", "Receiving...").
-* **Drag and Drop Functionality:**
-  * The entire application window, and specifically the list of discovered devices, will serve as a drop target.39
-  * Users can initiate a file transfer by dragging one or more files or folders from Finder and dropping them onto the desired device in the list.6
-  * During a drag operation, the target device list item should provide visual feedback, such as highlighting or changing its background color, to indicate it is a valid drop destination.
-* **Transfer Progress View:**
-  * When a transfer is active, a progress section will appear within the main window or in a separate modal sheet.
-  * This view will list all active transfers (both sending and receiving), each with a progress bar, text indicating percentage complete (e.g., "57%"), transfer speed (e.g., "45.5 MB/s"), and a cancel button.
-* **Settings Pane:**
-  * Accessible via a standard "Preferences" menu item or a gear icon in the main window.
-  * Allows the user to change their device's broadcast name.
-  * Allows the user to select their default download folder using a native macOS folder picker dialog.
-* **Menu Bar Integration:**
-  * The application will feature a persistent icon in the system menu bar.
-  * Clicking this icon will display a dropdown menu showing the app's status, a list of discovered devices, and options to open the main window or quit the application. This provides a quick, "at a glance" interface similar to AirDrop's.1
-* **macOS Share Extension (Post-MVP):**
-  * To achieve deeper OS integration, a Share Extension will be developed. This will allow users to send files to a WarpDeck peer directly from the standard "Share" menu in Finder and other applications, providing a workflow identical to AirDrop's Share Sheet functionality.1
-
-### **5.3. Platform Integration**
-
-Proper integration with macOS security and file system features is critical for the application to function correctly and be accepted for distribution.
-
-#### **5.3.1. App Sandbox and Entitlements**
-
-For security and for distribution on the Mac App Store, the WarpDeck application **must** be sandboxed.41 The App Sandbox restricts the application's access to system resources, requiring explicit permission for necessary capabilities via entitlements defined in the project's
-
-.entitlements file. Failure to correctly configure these will result in the application being blocked by the OS from performing network or file operations.
-
-The process of sandboxing necessitates a specific approach to file access. By default, a sandboxed app can only read and write freely within its own container directory (\~/Library/Containers/\<app-bundle-id\>). Access to user-specified locations like \~/Downloads is forbidden unless explicitly granted by the user. Simply storing a string path to the Downloads folder is insufficient and will fail after an app restart.
-
-The correct and robust mechanism to gain persistent access to a user-selected folder is through **security-scoped bookmarks**. When the user first chooses their download directory via a native NSOpenPanel, the application must create a security-scoped bookmark from the resulting folder URL. This bookmark data, which is essentially a secure token, is then stored persistently (e.g., in UserDefaults). On subsequent app launches, the application retrieves this bookmark data and resolves it to securely re-establish read/write access to that specific folder without requiring the user to grant permission again. This is a non-negotiable implementation detail for a seamless user experience in a sandboxed environment.43
-
-Table 5.3.1: Required macOS App Sandbox Entitlements
-| Entitlement Key | Xcode UI Name | Purpose in WarpDeck |
-| :--- | :--- | :--- |
-| com.apple.security.app-sandbox | App Sandbox | (Required) Enables the sandbox for the entire application. This is a prerequisite for Mac App Store distribution. 41 |
-
-| com.apple.security.network.client | Outgoing Connections (Client) | (Required) Allows the application to initiate outgoing TCP connections to other WarpDeck instances on the network. 45 |
-
-| com.apple.security.network.server | Incoming Connections (Server) | (Required) Allows the application's embedded HTTPS server to bind to a port and listen for incoming connections from other WarpDeck peers. 42 |
-
-| com.apple.security.files.user-selected.read-write | User Selected File (Read/Write) | (Required) Grants the application read/write access to a folder that the user explicitly selects via a standard Open or Save panel. This is essential for setting the initial download location. 44 |
-
-| com.apple.security.files.downloads.read-write | Downloads Folder (Read/Write) | (Optional, Recommended) Explicitly requests read/write access to the user's standard \~/Downloads folder. This can be used to provide a sensible default location. |
-
-#### **5.3.2. Security-Scoped Bookmarks Implementation Flow**
-
-The following logic must be implemented for managing the download location:
-
-1. **Check for Stored Bookmark:** On application startup, check persistent storage (e.g., UserDefaults) for existing security-scoped bookmark data.
-2. **Resolve Bookmark:** If bookmark data exists, call the URL(byResolvingBookmarkData:options:relativeTo:bookmarkDataIsStale:) method to get a URL with security scope. Call startAccessingSecurityScopedResource() on this URL. This re-establishes access for the current session.
-3. **First-Time Setup:** If no bookmark data exists, or if resolving fails, the application must prompt the user to select a download folder.
-4. **Prompt User:** Display a native NSOpenPanel to allow the user to choose a directory.
-5. **Create and Store Bookmark:** Upon user selection, create a new security-scoped bookmark from the returned URL using bookmarkData(options:includingResourceValuesForKeys:relativeTo:) with the withSecurityScope option.
-6. **Persist Bookmark:** Save the resulting Data object to persistent storage.
-7. **Release Access:** When the application is about to terminate or when access is no longer needed, call stopAccessingSecurityScopedResource() on the URL.
-
-## **Part VI: Steam Deck (Arch Linux) GUI Application Specification**
-
-This section details the requirements for the WarpDeck application on the Steam Deck platform. A key challenge is designing a single application that provides an excellent user experience in two vastly different environments: the standard KDE Plasma Desktop Mode and the controller-centric Gaming Mode.
-
-### **6.1. Architecture**
-
-* **Framework:** The application will be a single codebase built with **Flutter** and Dart, leveraging its cross-platform capabilities to target Linux.
-* **Core Integration:** The architecture is identical to the macOS version, using dart:ffi and the ffigen tool to interface with the shared C++ libwarpdeck library.
-* **Packaging:** The application will be packaged as a **Flatpak**. This is the recommended method for distributing applications on SteamOS, as it ensures all dependencies are bundled and operates within a sandboxed environment that writes only to the user's home directory, respecting the immutable nature of the root filesystem.48
-* **Installation:** The primary distribution channel will be Flathub, allowing users to easily install it from the Discover Software Center in Desktop Mode. A supplementary shell script will be provided to automatically create a "Non-Steam Game" entry in the user's Steam library, which makes the application launchable from Gaming Mode.50
-
-### **6.2. UI/UX for Desktop Mode**
-
-When launched from the KDE Plasma desktop environment, WarpDeck will present a standard desktop user interface.
-
-* **Design Language:** The UI will be functionally identical to the macOS version but may adopt Material 3 design principles or styles that blend well with the default SteamOS "Breeze" theme to feel more native to the environment.10
-* **Functionality:** It will provide the full feature set, including a main window with a device list, full drag-and-drop support from the Dolphin file manager, transfer progress views, and access to settings.
-* **System Integration:** The application will integrate with the system tray, providing a status icon and quick access to essential functions.
-
-### **6.3. UI/UX for Gaming Mode ("10-Foot UI")**
-
-When launched from the Steam Library in Gaming Mode, the application must present a completely different UI, designed from the ground up for a "10-foot" experience. This UI must be fully navigable and usable with the Steam Deck's built-in gamepad controls.
-
-The design of this interface cannot simply be a larger version of the desktop UI. It must follow established principles for console and TV interfaces, where navigation is based on moving a focus element between large, legible targets, rather than using a pointer.11 Clarity, simplicity, and immediate feedback are paramount.
-
-#### **6.3.1. Design Principles & Wireframes**
-
-* **Layout:** The UI will be structured around a grid or large list-based layout. A horizontal scrollable list could display discovered devices, while a vertical list could show the transfer queue and history. Navigation must be predictable in all four cardinal directions (up, down, left, right).53
-* **Legibility:** All text must be large and high-contrast. Font sizes should be a minimum of 22-24px to be comfortably readable from a distance of several feet.53 Sans-serif fonts with a medium weight are preferred.
-* **Focus Indication:** The currently selected UI element must have a highly visible focus state. This can be achieved with a combination of a bright, thick border (e.g., Steam's signature blue), a background glow, or a slight scaling effect. The focus state must be unmistakable from across a room.55
-* **Interaction:** All actions will be mapped to gamepad buttons. On-screen button prompts (e.g., icons for A, B, X, Y buttons) must be displayed contextually to guide the user. For example, when a transfer request notification appears, it should explicitly show "\[A\] Accept" and " Decline".57
-* **Sound Feedback:** Auditory feedback should be provided for key actions, such as navigating between items, confirming a selection, and completing a transfer, to reinforce user actions.9
-
-#### **6.3.2. Steam Input Integration**
-
-To ensure a seamless and customizable control experience, the application will not listen for raw joystick or keyboard events. Instead, it will integrate with the **Steam Input API**. This is the standard and required method for supporting controllers on Steam Deck.58
-
-* **Action Manifest:** The application will ship with an Action Manifest file (game\_actions\_\*.vdf) that defines a set of abstract in-game actions, such as NavigateUp, NavigateDown, Accept, Decline, OpenMenu.
-* **Default Configuration:** A default controller configuration will be provided, mapping the standard Steam Deck buttons to these abstract actions. This allows users to immediately use the application without any setup, but also gives them the power to remap controls using the standard Steam Input UI if they wish.
-* **Implementation:** The Flutter application will use a Steamworks SDK wrapper (either a community package or a custom FFI binding) to listen for these abstract Steam Input actions, not for specific key presses. This decouples the application logic from the physical hardware.
-
-Table 6.3.1: Default Steam Deck Gaming Mode Controller Mappings
-| Physical Control | Steam Input Action | UI Action Description |
-| :--- | :--- | :--- |
-| D-Pad / Left Stick | Navigate | Moves the focus highlight between selectable UI elements (devices, buttons, list items). |
-| A Button | Accept | Confirms the currently focused selection. Accepts an incoming transfer request. |
-| B Button | Back / Decline | Navigates to the previous screen or closes a menu. Declines an incoming transfer request. |
-| Y Button | Options | Opens a context menu for the currently focused item (e.g., "Forget this device"). |
-| Start Button | Menu | Opens the main application settings screen. |
-| Quick Access Button (...) | (System Reserved) | No application-specific action. Opens the system Quick Access Menu. |
-
-### **6.4. Platform Integration**
-
-Successfully deploying on SteamOS requires careful handling of its specific system architecture, particularly its immutable filesystem and firewall configuration.
-
-#### **6.4.1. Firewall Configuration**
-
-The default firewall configuration on SteamOS is a known point of ambiguity. While some local network services appear to work out-of-the-box, others may be blocked.59 The application cannot assume its listening port will be open. Furthermore, a Flatpak application is sandboxed and cannot directly modify system-level firewall rules.
-
-To provide a robust and user-friendly solution, the following first-run logic will be implemented:
-
-1. On first launch, the application will attempt to start its API server on the configured port.
-2. It will then perform a local self-check to see if the port is accessible from the local loopback address.
-3. If the self-check fails, it indicates that a firewall is likely blocking the port.
-4. The application will display a clear, one-time setup screen. This screen will explain that the firewall may be blocking connections and will provide the user with the exact firewall-cmd command needed to open the port.
-5. The user will be instructed to switch to Desktop Mode, open the Konsole terminal, and run the provided command. Example text:"To allow other devices to connect, please run the following command in the Desktop Mode terminal: sudo firewall-cmd \--permanent \--zone=home \--add-port=54321/tcp && sudo firewall-cmd \--reload"
-
-This approach empowers the user to correctly configure their system without the application attempting to perform unsafe operations like disabling the read-only filesystem.48
-
-#### **6.4.2. Filesystem and Installation**
-
-* **Filesystem Access:** As a Flatpak, the application will have its data stored in /home/deck/.var/app/com.warpdeck.app. It will have default access to the user's home directory. The default save location for received files will be /home/deck/Downloads, which is a standard and expected location for users.49
-* **Installation Script:** A simple shell script (add\_to\_steam.sh) will be provided alongside the Flatpak installation instructions. This script will perform the following actions:
-  1. Find the Flatpak application's ID (com.warpdeck.app).
-  2. Use Steam's command-line interface or modify configuration files to add a new entry to the user's library.
-  3. The entry's launch options will be set to run the Flatpak: flatpak run com.warpdeck.app \--gamemode.
-  4. The \--gamemode argument will signal to the Flutter application that it should launch directly into its 10-foot, controller-friendly UI.
-
-## **Part VII: Security, Distribution, and Compliance**
-
-This final part outlines the overarching security model and the critical steps required for successful application distribution and platform compliance.
-
-### **7.1. Security Model In-Depth**
-
-The security of WarpDeck is built on a layered defense-in-depth strategy appropriate for a local network peer-to-peer application.
-
-* **Protocol Security Summary:**
-  * **Discovery:** mDNS is used for discovery only. It does not transmit sensitive data, but the advertised device name is public on the LAN. The inclusion of the certificate fingerprint in the TXT record provides a basis for authentication before a connection is even made.
-  * **Transport Encryption:** All direct communication is encrypted using **TLS 1.3**. This ensures confidentiality (preventing eavesdropping) and integrity (preventing data tampering) for all API calls and file transfers on the network.4
-  * **Peer Authentication:** The **Trust On First Use (TOFU)** model provides peer authentication. It prevents man-in-the-middle attacks by ensuring that once a device's identity (its certificate fingerprint) is trusted, any future connection claiming to be that device must present the same certificate.32
-* **Certificate and Key Management:**
-  * The 2048-bit RSA private key is the most sensitive asset. It must be stored using the most secure mechanism available on each platform.
-  * **macOS:** The private key and self-signed certificate should be stored in the user's **Keychain** with an access control list that restricts access to the WarpDeck application only.
-  * **SteamOS/Linux:** The key and certificate should be stored in a file within the application's private data directory (\~/.var/app/com.warpdeck.app/data/) with file permissions set to be readable only by the user (600). Integration with the KDE Wallet System can be considered as a future enhancement.
-* **Trust Store Specification:**
-  * The trust store will be a simple JSON file stored in the application's configuration directory (e.g., trust\_store.json).
-  * The file will contain a list of trusted peer objects.
-  * Each object will contain the peer's unique id (UUID) and its fp (SHA-256 certificate fingerprint).
-  * This file must be protected by appropriate file system permissions.
-
-### **7.2. Distribution & Packaging**
-
-* **macOS Distribution:**
-  1. **Build:** The Flutter build process will generate a .app bundle.
-  2. **Codesign:** The .app bundle must be recursively codesigned using the codesign utility with a valid "Developer ID Application" certificate obtained from a paid Apple Developer account.
-  3. **Notarize:** The signed .app bundle (typically packaged in a .dmg or .zip archive) must be submitted to Apple's notarization service using the notarytool command-line utility. The service scans the app for malware and other issues.
-  4. **Staple:** Once notarization is successful, the resulting ticket must be "stapled" to the application bundle using stapler. This ensures that Gatekeeper on user machines can verify the app's integrity even when offline.38
-* **Steam Deck (Linux) Distribution:**
-  1. **Build:** The Flutter build process will generate the Linux executable and assets.
-  2. **Flatpak Manifest:** A com.warpdeck.app.json Flatpak manifest file will be created. This file defines the application's metadata, build commands, dependencies (e.g., avahi), and sandbox permissions (e.g., network access, home directory access).
-  3. **Packaging:** The flatpak-builder tool will be used to build the application against the manifest, creating a Flatpak bundle.
-  4. **Distribution:** The resulting bundle can be submitted to the Flathub repository for broad distribution or hosted in a custom Flatpak repository. Users can also install it directly from the bundle file.
-
-### **7.3. Platform Compliance Checklist**
-
-Adherence to platform guidelines is mandatory for distribution.
-
-#### **7.3.1. Apple App Store Review Guidelines**
-
-If distributing through the Mac App Store, the following guidelines are particularly relevant:
-
-* **Guideline 2.3.1 (Hidden Features):** The application must not contain hidden or undocumented features. The dual-UI logic for the Steam Deck version must be declared if a single codebase is submitted.
-* **Guideline 5.2.1 (Legal Entity):** The app must be submitted by the legal entity that owns it.62
-* **Guideline 5.2.3 (Illegal File Sharing):** The application's description and metadata must be explicit that it is for transferring user-owned files between the user's own devices on a local network. It must clearly state that it does not facilitate the download or sharing of media from third-party sources or the internet.62
-* **App Privacy Details:** A comprehensive and accurate privacy manifest must be submitted via App Store Connect. This must declare all data collected (e.g., user-provided device name) and the purpose of its collection (e.g., "App Functionality"). It must also cover any data collected by third-party packages used in the app.63
-* **Review Access:** The review team must be provided with a fully functional build. If testing requires two devices, clear instructions must be provided in the App Review notes.64
-
-#### **7.3.2. Steam Deck Verified Program**
-
-To achieve a "Verified" or "Playable" rating on Steam, the application must meet specific criteria when running in Gaming Mode.
-
-* **Input:**
-  * **Full Controller Support:** The application must be fully navigable and usable with the default Steam Deck controller layout. All functionality must be accessible without a mouse or keyboard.65
-  * **Appropriate Input Glyphs:** When displaying on-screen prompts, the app should use Steam Input API to show the correct glyphs for the currently active controller.
-  * **On-Screen Keyboard:** Any text input field (e.g., for setting the device name) must automatically invoke the Steam on-screen keyboard when selected. This requires a call to the Steamworks SDK function ShowFloatingGamepadTextInput or ShowGamepadTextInput.58
-* **Display:**
-  * **Native Resolution:** The application must default to the Steam Deck's native resolution (1280x800) and render correctly without letterboxing.65
-  * **Legibility:** All text in the Gaming Mode UI must be legible from a comfortable viewing distance (minimum font size requirements apply).65
-* **Seamlessness:**
-  * **No Compatibility Warnings:** The application should launch without any compatibility warnings.
-  * **System Support:** The application must be stable and integrate with system features like suspend and resume. It should handle potential network disconnections upon resuming from sleep gracefully.66
-* **Proton:**
-  * As a native Linux application, this category is less critical. However, the Flatpak packaging ensures that all necessary dependencies are bundled, avoiding issues related to missing libraries that can affect Proton-run games.7
+WarpDeck is released under the MIT License.


### PR DESCRIPTION
## Summary

- Rewrote README from 835 lines to 205 lines — removing the embedded PRD/technical specification
- Fixed broken links to nonexistent files (CONTRIBUTING.md, docs/ directory, LICENSE)
- Removed stale Q1-Q3 2025 roadmap and placeholder contact email
- Added clear architecture diagram, security model table, and "How It Works" flow
- Build instructions now correctly distinguish macOS (Homebrew OpenSSL) vs Linux (vcpkg)
- Added collapsible build-from-source sections to keep the README scannable

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify all badge URLs resolve
- [ ] Verify GitHub release download link works
- [ ] Confirm build instructions match actual build process